### PR TITLE
Use in-tree NSS by reverting BeOS port removal and applying haikuports patchset

### DIFF
--- a/haiku_mozconfig
+++ b/haiku_mozconfig
@@ -10,7 +10,7 @@ ac_add_options --with-system-jpeg
 ac_add_options --with-system-libevent
 ac_add_options --with-system-libvpx
 ac_add_options --with-system-nspr
-ac_add_options --with-system-nss
+#ac_add_options --with-system-nss
 # --with-system-png won't work because the system's libpng doesn't have APNG support
 #ac_add_options --with-system-png
 ac_add_options --with-system-webp

--- a/security/nss/cmd/httpserv/httpserv.c
+++ b/security/nss/cmd/httpserv/httpserv.c
@@ -1321,7 +1321,7 @@ main(int argc, char **argv)
         FILE *tmpfile = fopen(pidFile, "w+");
 
         if (tmpfile) {
-            fprintf(tmpfile, "%d", getpid());
+            fprintf(tmpfile, "%d", (int)getpid());
             fclose(tmpfile);
         }
     }

--- a/security/nss/cmd/lib/secpwd.c
+++ b/security/nss/cmd/lib/secpwd.c
@@ -13,6 +13,9 @@
 
 #ifdef XP_UNIX
 #include <termios.h>
+#endif
+
+#if defined(XP_UNIX) || defined(XP_BEOS)
 #include <unistd.h> /* for isatty() */
 #endif
 

--- a/security/nss/cmd/selfserv/selfserv.c
+++ b/security/nss/cmd/selfserv/selfserv.c
@@ -2881,7 +2881,7 @@ main(int argc, char **argv)
         FILE *tmpfile = fopen(pidFile, "w+");
 
         if (tmpfile) {
-            fprintf(tmpfile, "%d", getpid());
+            fprintf(tmpfile, "%d", (int)getpid());
             fclose(tmpfile);
         }
     }

--- a/security/nss/cmd/shlibsign/Makefile
+++ b/security/nss/cmd/shlibsign/Makefile
@@ -95,7 +95,9 @@ else
     endif
 endif
 
+ifndef SKIP_SHLIBSIGN
 libs: install
+endif
 ifdef CHECKLOC
 	$(MAKE) $(CHECKLOC)
 endif

--- a/security/nss/coreconf/BeOS.mk
+++ b/security/nss/coreconf/BeOS.mk
@@ -1,0 +1,47 @@
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+include $(CORE_DEPTH)/coreconf/UNIX.mk
+
+XP_DEFINE := $(XP_DEFINE:-DXP_UNIX=-DXP_BEOS)
+
+USE_PTHREADS = 
+
+ifeq ($(USE_PTHREADS),1)
+	IMPL_STRATEGY = _PTH
+endif
+
+CC			= gcc
+CCC			= g++
+RANLIB			= ranlib
+
+DEFAULT_COMPILER = gcc
+
+ifeq ($(OS_TEST),ppc)
+	OS_REL_CFLAGS	= -Dppc
+	CPU_ARCH	= ppc
+else
+	OS_REL_CFLAGS	= -Di386
+	CPU_ARCH	= x86
+endif
+
+MKSHLIB		= $(CC) -nostart -Wl,-soname -Wl,$(@:$(OBJDIR)/%.so=%.so)
+ifdef BUILD_OPT
+	OPTIMIZER	= -O2
+endif
+
+OS_CFLAGS		= $(DSO_CFLAGS) $(OS_REL_CFLAGS) -Wall -Wno-switch -pipe
+OS_LIBS			= -lbe
+
+DEFINES			+= -DBEOS
+
+ifdef USE_PTHREADS
+	DEFINES		+= -D_REENTRANT
+endif
+
+ARCH			= beos
+
+DSO_CFLAGS		= -fPIC
+DSO_LDOPTS		=

--- a/security/nss/coreconf/arch.mk
+++ b/security/nss/coreconf/arch.mk
@@ -35,6 +35,14 @@ endif
 
 
 #
+# Force the Haiku machines to use BeOS.
+#
+
+ifeq ($(OS_ARCH),Haiku)
+	OS_ARCH = BeOS
+endif
+
+#
 # Force the older BSD/OS versions to use the new arch name.
 #
 

--- a/security/nss/coreconf/config.mk
+++ b/security/nss/coreconf/config.mk
@@ -30,7 +30,7 @@ endif
 #       one for each OS release.                                      #
 #######################################################################
 
-TARGET_OSES = FreeBSD BSD_OS NetBSD OpenUNIX OS2 QNX Darwin OpenBSD \
+TARGET_OSES = FreeBSD BSD_OS NetBSD OpenUNIX OS2 QNX Darwin BeOS OpenBSD \
               AIX RISCOS WINNT WIN95 Linux Android
 
 ifeq (,$(filter-out $(TARGET_OSES),$(OS_TARGET)))

--- a/security/nss/coreconf/nsinstall/nsinstall.c
+++ b/security/nss/coreconf/nsinstall/nsinstall.c
@@ -26,11 +26,15 @@ typedef unsigned int mode_t;
 
 #define HAVE_LCHOWN
 
-#if defined(AIX) || defined(BSDI) || defined(HPUX) || defined(LINUX) || defined(SUNOS4) || defined(SCO) || defined(UNIXWARE) || defined(NTO) || defined(DARWIN) || defined(__riscos__)
+#if defined(AIX) || defined(BSDI) || defined(HPUX) || defined(LINUX) || defined(SUNOS4) || defined(SCO) || defined(UNIXWARE) || defined(NTO) || defined(DARWIN) || defined(BEOS) || defined(__riscos__)
 #undef HAVE_LCHOWN
 #endif
 
 #define HAVE_FCHMOD
+
+#if defined(BEOS)
+#undef HAVE_FCHMOD
+#endif
 
 #ifdef LINUX
 #include <getopt.h>

--- a/security/nss/lib/certhigh/ocsp.c
+++ b/security/nss/lib/certhigh/ocsp.c
@@ -146,7 +146,8 @@ cert_DupOCSPCertID(const CERTOCSPCertID *src);
 #define OCSP_TRACE_CERT(cert) dumpCertificate(cert)
 #define OCSP_TRACE_CERTID(certid) dumpCertID(certid)
 
-#if defined(XP_UNIX) || defined(XP_WIN32) || defined(XP_MACOSX)
+#if defined(XP_UNIX) || defined(XP_WIN32) || defined(XP_BEOS) || \
+    defined(XP_MACOSX)
 #define NSS_HAVE_GETENV 1
 #endif
 

--- a/security/nss/lib/dbm/include/mcom_db.h
+++ b/security/nss/lib/dbm/include/mcom_db.h
@@ -60,7 +60,7 @@ typedef PRUint32 uint32;
 #include <sys/byteorder.h>
 #endif
 
-#if defined(__linux) || defined(__BEOS__)
+#if defined(__linux) || defined(BEOS)
 #include <endian.h>
 #ifndef BYTE_ORDER
 #define BYTE_ORDER __BYTE_ORDER

--- a/security/nss/lib/dbm/include/mcom_db.h
+++ b/security/nss/lib/dbm/include/mcom_db.h
@@ -40,7 +40,7 @@
 #endif
 #include "prtypes.h"
 
-#if !defined(XP_OS2) && !defined(XP_UNIX) || defined(NTO)
+#if !defined(XP_BEOS) && !defined(XP_OS2) && !defined(XP_UNIX) || defined(NTO)
 typedef PRUintn uint;
 #endif
 typedef PRUint8 uint8;
@@ -60,7 +60,7 @@ typedef PRUint32 uint32;
 #include <sys/byteorder.h>
 #endif
 
-#if defined(__linux)
+#if defined(__linux) || defined(__BEOS__)
 #include <endian.h>
 #ifndef BYTE_ORDER
 #define BYTE_ORDER __BYTE_ORDER

--- a/security/nss/lib/freebl/Makefile
+++ b/security/nss/lib/freebl/Makefile
@@ -366,7 +366,7 @@ endif
 # to bind the blapi function references in FREEBLVector vector
 # (ldvector.c) to the blapi functions defined in the freebl
 # shared libraries.
-ifeq (,$(filter-out BSD_OS FreeBSD Linux NetBSD OpenBSD, $(OS_TARGET)))
+ifeq (,$(filter-out BSD_OS FreeBSD Linux NetBSD OpenBSD BeOS, $(OS_TARGET)))
     MKSHLIB += -Wl,-Bsymbolic
 endif
 

--- a/security/nss/lib/freebl/stubs.c
+++ b/security/nss/lib/freebl/stubs.c
@@ -813,6 +813,10 @@ freebl_InitNSSUtil(void *lib)
     return SECSuccess;
 }
 
+#ifndef RTLD_NOLOAD
+    #define RTLD_NOLOAD 0
+#endif
+
 /*
  * fetch the library if it's loaded. For NSS it should already be loaded
  */

--- a/security/nss/lib/freebl/sysrand.c
+++ b/security/nss/lib/freebl/sysrand.c
@@ -8,9 +8,9 @@
 
 #include "seccomon.h"
 
-#if defined(XP_UNIX) && defined(SEED_ONLY_DEV_URANDOM)
+#if (defined(XP_UNIX) || defined(XP_BEOS)) && defined(SEED_ONLY_DEV_URANDOM)
 #include "unix_urandom.c"
-#elif defined(XP_UNIX)
+#elif defined(XP_UNIX) || defined(XP_BEOS)
 #include "unix_rand.c"
 #endif
 #ifdef XP_WIN

--- a/security/nss/lib/freebl/unix_rand.c
+++ b/security/nss/lib/freebl/unix_rand.c
@@ -543,6 +543,39 @@ GiveSystemInfo(void)
 }
 #endif /* sinix */
 
+#ifdef BEOS
+#include <be/kernel/OS.h>
+
+static size_t
+GetHighResClock(void *buf, size_t maxbytes)
+{
+    bigtime_t bigtime; /* Actually a int64 */
+
+    bigtime = real_time_clock_usecs();
+    return CopyLowBits(buf, maxbytes, &bigtime, sizeof(bigtime));
+}
+
+static void
+GiveSystemInfo(void)
+{
+    system_info *info = NULL;
+    PRInt32 val;
+    get_system_info(info);
+    if (info) {
+        val = info->boot_time;
+        RNG_RandomUpdate(&val, sizeof(val));
+        val = info->used_pages;
+        RNG_RandomUpdate(&val, sizeof(val));
+        val = info->used_ports;
+        RNG_RandomUpdate(&val, sizeof(val));
+        val = info->used_threads;
+        RNG_RandomUpdate(&val, sizeof(val));
+        val = info->used_teams;
+        RNG_RandomUpdate(&val, sizeof(val));
+    }
+}
+#endif /* BEOS */
+
 #if defined(nec_ews)
 #include <sys/systeminfo.h>
 
@@ -616,6 +649,16 @@ RNG_SystemInfoForRNG(void)
 #else
     extern char **environ;
 #endif
+#ifdef BEOS
+    static const char *const files[] = {
+        "/boot/var/swap",
+        "/boot/var/log/syslog",
+        "/boot/var/tmp",
+        "/boot/home/config/settings",
+        "/boot/home",
+        0
+    };
+#else
     static const char *const files[] = {
         "/etc/passwd",
         "/etc/utmp",
@@ -624,6 +667,7 @@ RNG_SystemInfoForRNG(void)
         "/usr/tmp",
         0
     };
+#endif
 
     GiveSystemInfo();
 

--- a/security/nss/lib/jar/jar.h
+++ b/security/nss/lib/jar/jar.h
@@ -140,7 +140,7 @@ typedef struct JAR_Physical_ {
     unsigned long offset;
     unsigned long length;
     unsigned long uncompressed_length;
-#if defined(XP_UNIX)
+#if defined(XP_UNIX) || defined(XP_BEOS)
     PRUint16 mode;
 #endif
 } JAR_Physical;

--- a/security/nss/lib/jar/jarfile.c
+++ b/security/nss/lib/jar/jarfile.c
@@ -16,7 +16,7 @@
 /* commercial compression */
 #include "jzlib.h"
 
-#if defined(XP_UNIX)
+#if defined(XP_UNIX) || defined(XP_BEOS)
 #include "sys/stat.h"
 #endif
 
@@ -219,7 +219,7 @@ JAR_extract(JAR *jar, char *path, char *outpath)
                                           (unsigned int)phy->compression);
         }
 
-#if defined(XP_UNIX)
+#if defined(XP_UNIX) || defined(XP_BEOS)
         if (phy->mode)
             chmod(outpath, 0400 | (mode_t)phy->mode);
 #endif
@@ -764,7 +764,7 @@ jar_listzip(JAR *jar, JAR_FILE fp)
                 goto loser;
             }
 
-#if defined(XP_UNIX)
+#if defined(XP_UNIX) || defined(XP_BEOS)
             /* with unix we need to locate any bits from
                the protection mask in the external attributes. */
             attr = Central->external_attributes[2]; /* magic */

--- a/security/nss/lib/nss/nssinit.c
+++ b/security/nss/lib/nss/nssinit.c
@@ -261,7 +261,7 @@ static const char *dllname =
     "libnssckbi.sl";
 #elif defined(DARWIN)
     "libnssckbi.dylib";
-#elif defined(XP_UNIX)
+#elif defined(XP_UNIX) || defined(XP_BEOS)
     "libnssckbi.so";
 #else
 #error "Uh! Oh! I don't know about this platform."

--- a/security/nss/lib/ssl/config.mk
+++ b/security/nss/lib/ssl/config.mk
@@ -44,6 +44,10 @@ EXTRA_SHARED_LIBS += \
 	-lnspr4 \
 	$(NULL)
 
+ifeq ($(OS_ARCH), BeOS)
+EXTRA_SHARED_LIBS += -lbe
+endif
+
 endif
 
 ifdef NSS_DISABLE_TLS_1_3

--- a/security/nss/lib/ssl/sslimpl.h
+++ b/security/nss/lib/ssl/sslimpl.h
@@ -24,7 +24,7 @@
 #include "hasht.h"
 #include "nssilock.h"
 #include "pkcs11t.h"
-#if defined(XP_UNIX)
+#if defined(XP_UNIX) || defined(XP_BEOS)
 #include "unistd.h"
 #elif defined(XP_WIN)
 #include <process.h>
@@ -2053,7 +2053,7 @@ SECStatus SSLExp_CallExtensionWriterOnEchInner(PRFileDesc *fd, PRBool enabled);
 
 SEC_END_PROTOS
 
-#if defined(XP_UNIX) || defined(XP_OS2)
+#if defined(XP_UNIX) || defined(XP_OS2) || defined(XP_BEOS)
 #define SSL_GETPID getpid
 #elif defined(WIN32)
 #define SSL_GETPID _getpid

--- a/security/nss/lib/ssl/sslmutex.c
+++ b/security/nss/lib/ssl/sslmutex.c
@@ -4,7 +4,7 @@
 
 #include "seccomon.h"
 /* This ifdef should match the one in sslsnce.c */
-#if defined(XP_UNIX) || defined(XP_WIN32) || defined(XP_OS2)
+#if defined(XP_UNIX) || defined(XP_WIN32) || defined(XP_OS2) || defined(XP_BEOS)
 
 #include "sslmutex.h"
 #include "prerr.h"
@@ -60,7 +60,7 @@ single_process_sslMutex_Lock(sslMutex* pMutex)
     return SECSuccess;
 }
 
-#if defined(LINUX) || defined(AIX) || defined(BSDI) || \
+#if defined(LINUX) || defined(AIX) || defined(BEOS) || defined(BSDI) || \
     (defined(NETBSD) && __NetBSD_Version__ < 500000000) || defined(OPENBSD) || defined(__GLIBC__)
 
 #include <unistd.h>

--- a/security/nss/lib/ssl/sslmutex.h
+++ b/security/nss/lib/ssl/sslmutex.h
@@ -49,7 +49,7 @@ typedef struct {
 
 typedef int sslPID;
 
-#elif defined(LINUX) || defined(AIX) || defined(BSDI) || \
+#elif defined(LINUX) || defined(AIX) || defined(BEOS) || defined(BSDI) || \
     (defined(NETBSD) && __NetBSD_Version__ < 500000000) || defined(OPENBSD) || defined(__GLIBC__)
 
 #include <sys/types.h>

--- a/security/nss/lib/ssl/sslnonce.c
+++ b/security/nss/lib/ssl/sslnonce.c
@@ -16,7 +16,7 @@
 #include "sslproto.h"
 #include "nssilock.h"
 #include "sslencode.h"
-#if defined(XP_UNIX) || defined(XP_WIN) || defined(_WINDOWS)
+#if defined(XP_UNIX) || defined(XP_WIN) || defined(_WINDOWS) || defined(XP_BEOS)
 #include <time.h>
 #endif
 

--- a/security/nss/lib/ssl/sslsnce.c
+++ b/security/nss/lib/ssl/sslsnce.c
@@ -45,7 +45,7 @@
  */
 #include "seccomon.h"
 
-#if defined(XP_UNIX) || defined(XP_WIN32) || defined(XP_OS2)
+#if defined(XP_UNIX) || defined(XP_WIN32) || defined(XP_OS2) || defined(XP_BEOS)
 
 #include "cert.h"
 #include "ssl.h"
@@ -60,7 +60,7 @@
 #include "selfencrypt.h"
 #include <stdio.h>
 
-#if defined(XP_UNIX)
+#if defined(XP_UNIX) || defined(XP_BEOS)
 
 #include <syslog.h>
 #include <fcntl.h>
@@ -268,11 +268,11 @@ typedef struct inheritanceStr inheritance;
 
 #endif /* _win32 */
 
-#if defined(XP_UNIX)
+#if defined(XP_UNIX) || defined(XP_BEOS)
 
 #define DEFAULT_CACHE_DIRECTORY "/tmp"
 
-#endif /* XP_UNIX */
+#endif /* XP_UNIX || XP_BEOS */
 
 /************************************************************************/
 
@@ -1047,7 +1047,7 @@ InitCache(cacheDesc *cache, int maxCacheEntries, int maxCertCacheEntries,
 
     if (shared) {
 /* Create file names */
-#if defined(XP_UNIX)
+#if defined(XP_UNIX) || defined(XP_BEOS)
         /* there's some confusion here about whether PR_OpenAnonFileMap wants
         ** a directory name or a file name for its first argument.
         cfn = PR_smprintf("%s/.sslsvrcache.%d", directory, myPid);
@@ -1231,7 +1231,7 @@ SSL_ShutdownServerSessionIDCacheInstance(cacheDesc *cache)
 SECStatus
 SSL_ShutdownServerSessionIDCache(void)
 {
-#if defined(XP_UNIX)
+#if defined(XP_UNIX) || defined(XP_BEOS)
     /* Stop the thread that polls cache for expired locks on Unix */
     StopLockPoller(&globalCache);
 #endif
@@ -1295,7 +1295,7 @@ ssl_ConfigMPServerSIDCacheWithOpt(PRUint32 ssl3_timeout,
         result = SECFailure;
     }
 
-#if defined(XP_UNIX)
+#if defined(XP_UNIX) || defined(XP_BEOS)
     /* Launch thread to poll cache for expired locks on Unix */
     LaunchLockPoller(cache);
 #endif
@@ -1519,7 +1519,7 @@ SSL_InheritMPServerSIDCache(const char *envString)
     return SSL_InheritMPServerSIDCacheInstance(&globalCache, envString);
 }
 
-#if defined(XP_UNIX)
+#if defined(XP_UNIX) || defined(XP_BEOS)
 
 #define SID_LOCK_EXPIRATION_TIMEOUT 30 /* seconds */
 

--- a/security/nss/lib/ssl/sslsock.c
+++ b/security/nss/lib/ssl/sslsock.c
@@ -3901,7 +3901,7 @@ loser:
     return SECFailure;
 }
 
-#if defined(XP_UNIX) || defined(XP_WIN32)
+#if defined(XP_UNIX) || defined(XP_WIN32) || defined(XP_BEOS)
 #define NSS_HAVE_GETENV 1
 #endif
 

--- a/security/nss/lib/ssl/unix_err.c
+++ b/security/nss/lib/ssl/unix_err.c
@@ -18,7 +18,7 @@
 #include "prerror.h"
 #endif
 
-#if defined(__bsdi__) || defined(NTO) || defined(DARWIN)
+#if defined(__bsdi__) || defined(NTO) || defined(DARWIN) || defined(BEOS)
 #undef _PR_POLL_AVAILABLE
 #endif
 

--- a/security/nss/lib/util/secport.c
+++ b/security/nss/lib/util/secport.c
@@ -31,7 +31,7 @@
 #include "prthread.h"
 #endif /* THREADMARK */
 
-#if defined(XP_UNIX) || defined(XP_OS2)
+#if defined(XP_UNIX) || defined(XP_OS2) || defined(XP_BEOS)
 #include <stdlib.h>
 #else
 #include "wtypes.h"

--- a/security/nss/lib/util/secport.h
+++ b/security/nss/lib/util/secport.h
@@ -13,7 +13,7 @@
 #include "prlink.h"
 
 /*
- * define XP_WIN, or XP_UNIX, in case they are not defined
+ * define XP_WIN, XP_BEOS, or XP_UNIX, in case they are not defined
  * by anyone else
  */
 #ifdef _WINDOWS
@@ -24,6 +24,12 @@
 #ifndef XP_WIN32
 #define XP_WIN32
 #endif
+#endif
+#endif
+
+#ifdef __BEOS__
+#ifndef XP_BEOS
+#define XP_BEOS
 #endif
 #endif
 


### PR DESCRIPTION
- 266edbdab570ef1828bb092e39d87d372307908f
  - Revert https://phabricator.services.mozilla.com/D37215
- 22f2a537819bed851918e128029c65d9a820fb2a
  - Apply https://github.com/haikuports/haikuports/blob/master/dev-libs/nss/patches/nss-3.73.1.patchset