### PR TITLE
Rename our port to Forefix for now

### DIFF
--- a/haiku_mozconfig
+++ b/haiku_mozconfig
@@ -3,6 +3,7 @@ ac_add_options --disable-audio-backends
 ac_add_options --disable-jit
 ac_add_options --disable-tests
 ac_add_options --disable-updater
+ac_add_options --with-app-name=Forefix
 ac_add_options --with-system-ffi
 # error: use of undeclared identifier 'UNUM_APPROXIMATELY_SIGN_FIELD'; did you mean 'UNUM_APPROXIMATELY_SIGN_SYMBOL'?
 #ac_add_options --with-system-icu


### PR DESCRIPTION
- not to violate mozilla's distribution guidelines

closes #70 