### PR TITLE
Fix regression of popup style change which some scrollable popups won't scroll

### DIFF
--- a/toolkit/themes/shared/popup.css
+++ b/toolkit/themes/shared/popup.css
@@ -45,8 +45,8 @@ panel {
 
   /* Disable border-radius and shadow for Haiku popups */
   @media (-moz-platform: linux) {
-    --panel-border-radius: 0;
-    --panel-shadow-margin: 0;
+    --panel-border-radius: 0px;
+    --panel-shadow-margin: 0px;
   }
 
   @media (-moz-platform: macos) {


### PR DESCRIPTION
- "Search for more languages..." popup's scroll is broken.
- We should have set haiku-specific CSS vars with its units for CSS calc.